### PR TITLE
Mr.Anderson oldgen honk fix

### DIFF
--- a/src/pages/Honkdex/HonkdexBootstrappable.ts
+++ b/src/pages/Honkdex/HonkdexBootstrappable.ts
@@ -49,8 +49,20 @@ export const MixinHonkdexBootstrappable = <
       super();
 
       this.instanceId = instanceId;
-      this.gen = gen;
-      this.format = getGenfulFormat(gen, format);
+
+      // Check if state exists for this ID
+      const existingState = this.calcdexState;
+
+      // If saved data exists, respect its generation. Otherwise, use the default.
+      if (existingState) {
+        this.gen = existingState.gen;
+        this.format = existingState.format;
+      } else {
+        this.gen = gen;
+        this.format = getGenfulFormat(gen, format);
+      }
+
+      // Now perform the sanity check
 
       if (this.calcdexState?.battleId && this.calcdexState.gen !== this.gen) {
         this.instanceId = uuidv4();


### PR DESCRIPTION
    The Bug:
    When opening a saved Honkdex instance (e.g., Gen 3), the constructor in HonkdexBootstrappable.ts was initializing with the default generation (Gen 9) before checking the saved state.

    This triggered the safety check if (this.calcdexState.gen !== this.gen), causing the app to treat the mismatch as invalid and generating a new random UUID (blank instance) instead of loading the saved data.

    The Fix:
    Updated the constructor to check if calcdexState exists for the provided instanceId. If it does, use the saved gen and format instead of the defaults.